### PR TITLE
Use compact_child_nodes

### DIFF
--- a/lib/syntax_finder.rb
+++ b/lib/syntax_finder.rb
@@ -23,7 +23,7 @@ class SyntaxFinder
   end
 
   def traverse_rest node
-    node.child_nodes.compact.each do |child|
+    node.compact_child_nodes.each do |child|
       traverse child
     end
   end 


### PR DESCRIPTION
It's slightly more efficient because it starts out compacted, so it removes the extra array allocation.